### PR TITLE
Feat - Add swagger tool for documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,12 @@
   },
   "homepage": "https://github.com/yoniihdc/node-express-es6-airbnb#readme",
   "dependencies": {
-    "express": "^4.16.2"
+    "body-parser": "^1.18.2",
+    "cors": "^2.8.4",
+    "express": "^4.16.2",
+    "morgan-body": "^2.3.1",
+    "swagger-jsdoc": "^1.9.7",
+    "swagger-ui-express": "^2.0.15"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -34,13 +39,11 @@
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-stage-0": "^6.24.1",
-    "cors": "^2.8.4",
     "eslint": "^4.13.1",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.5.1",
-    "morgan-body": "^2.3.1",
     "pre-commit": "^1.2.2",
     "rimraf": "^2.6.2"
   }

--- a/src/config/dev.js
+++ b/src/config/dev.js
@@ -1,4 +1,0 @@
-export default {
-  port: 3005,
-  bodyLimit: '100kb',
-}

--- a/src/config/dev.js.sample
+++ b/src/config/dev.js.sample
@@ -1,4 +1,6 @@
 export default {
   port: 3005,
   bodyLimit: '100kb',
+  API_URL: 'http://localhost',
+  API_PORT: 3005
 }

--- a/src/config/swagger.js
+++ b/src/config/swagger.js
@@ -1,0 +1,18 @@
+import config from './index';
+
+const swaggerDefinition = {
+  info: {
+    title: 'node-express-es6-airbnb',
+    version: '0.0.1',
+    description: 'node-express-es6-airbnb is a project that provides you with a boilerplate tool to create a <a href="https://nodejs.org/en/">node.js</a> API with an ES6 transpiler while following the <a href="https://github.com/airbnb/javascript">Airbnb Javascript (ES6) Style Guide</a>.',
+  },
+  host: `${config.API_URL}:${config.API_PORT}`,
+  basePath: '/',
+};
+
+const swaggerOptions = {
+  swaggerDefinition,
+  apis: ['./src/routes/*.js']
+};
+
+export default swaggerOptions;

--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,36 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import cors from 'cors';
 import morganBody from 'morgan-body';
+import swaggerJSDoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
+
 import config from './config';
 import routes from './routes';
+import swaggerOptions from './config/swagger';
 
 const app = express();
 app.server = http.createServer(app);
 
 // middleware
 app.use(cors());
+
+// swagger Documentation
+const swaggerSpec = swaggerJSDoc(swaggerOptions);
+const swaggerUiHandler = swaggerUi.setup(swaggerSpec);
+const docsJsonPath = '/api-docs.json';
+
+app.get(docsJsonPath, (req, res) => {
+  res.setHeader('Content-Type', 'application/json');
+  res.send(swaggerSpec);
+});
+
+app.use('/docs', swaggerUi.serve, (req, res, next) => {
+  if (!req.query.url) {
+    res.redirect(`/docs?url=${req.protocol}://${req.headers.host}${docsJsonPath}`);
+  } else {
+    swaggerUiHandler(req, res, next);
+  }
+});
 
 app.use(bodyParser.json({
   limit: config.bodyLimit,
@@ -27,4 +49,5 @@ app.use('/api', routes);
 app.server.listen(config.port);
 
 console.log(`Started on 'http://localhost:${app.server.address().port}'`);
+
 export default app;

--- a/src/routes/demo.js
+++ b/src/routes/demo.js
@@ -6,6 +6,20 @@ const { demo } = demoController;
 
 const api = Router();
 
+/**
+ * @swagger
+ * /api/demo:
+ *   get:
+ *     tags: ["Demo"]
+ *     description: Retrieves a JSON object with <b>hello world<b>
+ *     produces:
+ *      - application/json
+ *     responses:
+ *       200:
+ *         description: Success
+ *         schema:
+ *           $ref: '#/definitions/demo'
+ */
 api.get('/', demo.hi);
 
 export default api;

--- a/src/routes/swaggerModels.js
+++ b/src/routes/swaggerModels.js
@@ -1,0 +1,10 @@
+/**
+ * @swagger
+ * definitions:
+ *   demo:
+ *     type: object
+ *     properties:
+ *       hello:
+ *         type: string
+ *         description: Hello world message
+ */


### PR DESCRIPTION
#### What does this PR do?
This PR includes swagger as documentation tool for endpoints

#### Where should the reviewer start?
`/src/index.js` 
`/src/config/swagger.js`
`/src/routes/demo.js`
`/src/routes/swaggerModels.js`

#### How should this be manually tested?
Checkout this branch, and go to `http://localhost:3005/docs`

#### Screenshots
Inline documentation
![imagen](https://user-images.githubusercontent.com/6007230/36609629-1debb95c-1893-11e8-9715-cdae0be492e1.png)

Results
![imagen](https://user-images.githubusercontent.com/6007230/36609622-1704baf8-1893-11e8-9e01-9eee3c510f64.png)

